### PR TITLE
Remove "flickering" of normal StackOverflow layout

### DIFF
--- a/src/Chrome/content.css
+++ b/src/Chrome/content.css
@@ -1,0 +1,3 @@
+body {
+  visibility: hidden;
+}

--- a/src/Chrome/content.js
+++ b/src/Chrome/content.js
@@ -3,37 +3,37 @@ let width = "65";
 var isShadow = true;
 let bgColour = "rgb(50,50,50)"
 
+// We add our focus styles using a custom <style> element on the page
+// This will create the element and add it to the documents head
 const styleElement = document.createElement('style');
 styleElement.id = 'so-focus-styles';
-
 document.addEventListener("DOMContentLoaded", () => {
     document.head.appendChild(styleElement);
 });
 
+// We save our styles in this object so we can easily overwrite and change values
+// This object uses the structure styles[CSS-Selector][Property Name] = value;
 let styles = {};
 
+// Reload and write styles if we are in focus mode
+// This will allow us to refresh all values
 function reloadStyles() {
     if (isFocused) {
         focusStack();
     }
 }
 
+// Load our settings from local storage
 function updateSettings() {
     // Load width setting from storage
     try {
-        chrome.storage.local.get(['width'], function (data) {
+        chrome.storage.local.get(['width', 'isShadow', 'bgColour'], function (data) {
             if (typeof data.width == "string") {
                 width = data.width;
             }
-            reloadStyles();
-        })
-        chrome.storage.local.get(['isShadow'], function (data) {
             if (typeof data.isShadow == "boolean") {
                 isShadow = data.isShadow;
             }
-            reloadStyles();
-        })
-        chrome.storage.local.get(['bgColour'], function (data) {
             if (typeof data.bgColour == "string") {
                 bgColour = data.bgColour;
             }
@@ -55,6 +55,7 @@ function changeStyle(selector, styleProp, data) {
 
 // Write our styles to the stylesheet element
 function flushStyles() {
+    // Generate a CSS Stylesheet from our styles object
     let stylesheet = '';
     for(let selector in styles) {
         stylesheet += `${selector} {`;
@@ -68,12 +69,14 @@ function flushStyles() {
 
     styleElement.innerHTML = stylesheet;
 
+    // Make sure our body element is visible
     document.body.style.visibility = 'visible';
 }
 
 function focusStack(){
     // Body
     changeStyle("body", "background", bgColour)
+
     // Center top question sub headder
     changeStyle(".inner-content:nth-child(1)", "margin", "auto")
     changeStyle(".inner-content:nth-child(1)", "maxWidth", "728px")
@@ -111,16 +114,17 @@ function focusStack(){
     changeStyle(".top-bar", "display", "none")
     changeStyle(".js-dismissable-hero", "display", "none")
     
+    // Write our changes to the site's stylesheet
     flushStyles();
 
     isFocused = true;
 }
 
-updateSettings();
 document.addEventListener("DOMContentLoaded", focusStack);
+updateSettings();
 
 function unFocusStack(){
-    // Body
+    // Simply remove all our custom styles
     styles = {};
     flushStyles();
 
@@ -146,7 +150,7 @@ chrome.storage.local.onChanged.addListener(function (changes) {
         width = changes.width.newValue;
         // Update the page directly if we are already focused
         if (isFocused) {
-            changeStyle(".content", "width", width + "%")
+            changeStyle("#content", "width", width + "%")
             flushStyles();
         }
     } 
@@ -156,11 +160,11 @@ chrome.storage.local.onChanged.addListener(function (changes) {
         // Update the page directly if we are already focused
         if (isFocused) {
             if (changes.isShadow.newValue) {
-                changeStyle("content", "box-shadow", "0px 15px 80px -10px rgba(0, 0, 0, 0.8)")
+                changeStyle("#content", "box-shadow", "0px 15px 80px -10px rgba(0, 0, 0, 0.8)")
             } else{
-                changeStyle("content", "box-shadow", "0px 0px 0px 0px rgba(0, 0, 0, 0)")
+                changeStyle("#content", "box-shadow", "0px 0px 0px 0px rgba(0, 0, 0, 0)")
             }
-            
+            flushStyles();
         } 
     }
 
@@ -169,7 +173,8 @@ chrome.storage.local.onChanged.addListener(function (changes) {
         // alert(bgColour)
         // Update the page directly if we are already focused
         if (isFocused) {
-            document.getElementsByTagName("body")[0].style.background = bgColour
+            changeStyle('body', 'background', bgColour);
+            flushStyles();
         }
     } 
 });

--- a/src/Chrome/content.js
+++ b/src/Chrome/content.js
@@ -12,31 +12,36 @@ document.addEventListener("DOMContentLoaded", () => {
 
 let styles = {};
 
-function updateSettings(callback) {
+function reloadStyles() {
+    if (isFocused) {
+        focusStack();
+    }
+}
+
+function updateSettings() {
     // Load width setting from storage
     try {
         chrome.storage.local.get(['width'], function (data) {
             if (typeof data.width == "string") {
                 width = data.width;
-                // alert(width)
             }
-            callback();
+            reloadStyles();
         })
         chrome.storage.local.get(['isShadow'], function (data) {
             if (typeof data.isShadow == "boolean") {
                 isShadow = data.isShadow;
             }
-            callback();
+            reloadStyles();
         })
         chrome.storage.local.get(['bgColour'], function (data) {
             if (typeof data.bgColour == "string") {
                 bgColour = data.bgColour;
             }
-            callback();
+            reloadStyles();
         })
     } catch(e) {
         // We haven't stored a width setting yet
-        callback()
+        reloadStyles()
     }
 }
 
@@ -62,6 +67,8 @@ function flushStyles() {
     }
 
     styleElement.innerHTML = stylesheet;
+
+    document.body.style.visibility = 'visible';
 }
 
 function focusStack(){
@@ -109,9 +116,8 @@ function focusStack(){
     isFocused = true;
 }
 
-updateSettings(() => {
-    document.addEventListener("DOMContentLoaded", focusStack);
-})
+updateSettings();
+document.addEventListener("DOMContentLoaded", focusStack);
 
 function unFocusStack(){
     // Body

--- a/src/Chrome/content.js
+++ b/src/Chrome/content.js
@@ -3,6 +3,15 @@ let width = "65";
 var isShadow = true;
 let bgColour = "rgb(50,50,50)"
 
+const styleElement = document.createElement('style');
+styleElement.id = 'so-focus-styles';
+
+document.addEventListener("DOMContentLoaded", () => {
+    document.head.appendChild(styleElement);
+});
+
+let styles = {};
+
 function updateSettings(callback) {
     // Load width setting from storage
     try {
@@ -31,83 +40,83 @@ function updateSettings(callback) {
     }
 }
 
-function changeStyle(elementID, styleProp, data){
-    document.getElementById(elementID).style[styleProp] = data
+function changeStyle(selector, styleProp, data) {
+    if (!styles[selector]) {
+        styles[selector] = {};
+    }
+
+    styles[selector][styleProp] = data;
+}
+
+// Write our styles to the stylesheet element
+function flushStyles() {
+    let stylesheet = '';
+    for(let selector in styles) {
+        stylesheet += `${selector} {`;
+
+        for(let prop in styles[selector]) {
+            stylesheet += `${prop}: ${styles[selector][prop]} !important;`;
+        }
+
+        stylesheet += '}';
+    }
+
+    styleElement.innerHTML = stylesheet;
 }
 
 function focusStack(){
     // Body
-    document.getElementsByTagName("body")[0].style.background = bgColour
+    changeStyle("body", "background", bgColour)
     // Center top question sub headder
-    document.getElementById("mainbar").parentElement.children[1].style.margin = "auto"
-    document.getElementById("mainbar").parentElement.children[1].style.maxWidth = "728px"
+    changeStyle(".inner-content:nth-child(1)", "margin", "auto")
+    changeStyle(".inner-content:nth-child(1)", "maxWidth", "728px")
 
-    changeStyle("sidebar", "display", "none")
-    changeStyle("left-sidebar", "display", "none")
+    changeStyle("#sidebar", "display", "none")
+    changeStyle("#left-sidebar", "display", "none")
     // Center main content
-    changeStyle("content", "border", "0px")
-    changeStyle("content", "width", width + "%")
-    changeStyle("content", "max-width", "none")
-    changeStyle("content", "min-width", "500px")
-    changeStyle("content", "margin-bottom", "60px")
-    changeStyle("content", "border-radius", "10px")
+    changeStyle("#content", "border", "0px")
+    changeStyle("#content", "width", width + "%")
+    changeStyle("#content", "max-width", "initial")
+    changeStyle("#content", "margin-bottom", "60px")
+    changeStyle("#content", "border-radius", "10px")
     if (isShadow) {
-        changeStyle("content", "box-shadow", "0px 15px 80px -10px rgba(0, 0, 0, 0.8)")
+        changeStyle("#content", "box-shadow", "0px 15px 80px -10px rgba(0, 0, 0, 0.8)")
     } else{
-        changeStyle("content", "box-shadow", "0px 0px 0px 0px rgba(0, 0, 0, 0)")
+        changeStyle("#content", "box-shadow", "0px 0px 0px 0px rgba(0, 0, 0, 0)")
     }
-        
+
     // Center main content
-    changeStyle("mainbar", "float", "none")
-    changeStyle("mainbar", "margin", "auto")
-    changeStyle("mainbar", "width", "90%")
+    changeStyle("#mainbar", "float", "none")
+    changeStyle("#mainbar", "margin", "auto")
+    changeStyle("#mainbar", "width", "90%")
     // Center top question headder
-    changeStyle("question-header", "margin", "auto")
-    changeStyle("question-header", "width", "100%")
-    changeStyle("question-header", "maxWidth", "728px")
+    changeStyle("#question-header", "margin", "auto")
+    changeStyle("#question-header", "width", "100%")
+    changeStyle("#question-header", "maxWidth", "728px")
 
     // Container
-    document.querySelector('.container').setAttribute('id', 'container')
-    changeStyle("container", "margin", 0)
-    changeStyle("container", "max-width", "initial")
+    changeStyle(".container", "margin", 0)
+    changeStyle(".container", "max-width", "initial")
 
     // Footer
-    document.querySelector(".site-footer--container").style.display = "none"
+    changeStyle(".site-footer--container", "display", "none")
     // Hide top bar
-    document.querySelector(".top-bar").style.display = "none"
-    if(document.querySelector(".js-dismissable-hero")){
-        document.querySelector(".js-dismissable-hero").style.display = "none"
-    }
+    changeStyle(".top-bar", "display", "none")
+    changeStyle(".js-dismissable-hero", "display", "none")
+    
+    flushStyles();
 
     isFocused = true;
 }
 
-updateSettings(focusStack)
+updateSettings(() => {
+    document.addEventListener("DOMContentLoaded", focusStack);
+})
 
 function unFocusStack(){
     // Body
-    document.getElementsByTagName("body")[0].style = ""
-    // Center top question sub headder
-    document.getElementById("mainbar").parentElement.children[1].style = ""
-
-    document.getElementById("sidebar").style = ""
-    document.getElementById("left-sidebar").style = ""    
-    // Center main content
-    document.getElementById("content").style = ""
-
-    // Center main content
-    document.getElementById("mainbar").style = ""
-    // Center top question headder
-    document.getElementById("question-header").style = ""
-
-    // Hide top bar
-    document.querySelector(".top-bar").style = ""
-
-    // Footer
-    document.querySelector(".site-footer--container").style = ""
-    if(document.querySelector(".js-dismissable-hero")){
-        document.querySelector(".js-dismissable-hero").style = ""
-    }
+    styles = {};
+    flushStyles();
 
     isFocused = false;
 }
@@ -131,7 +140,8 @@ chrome.storage.local.onChanged.addListener(function (changes) {
         width = changes.width.newValue;
         // Update the page directly if we are already focused
         if (isFocused) {
-            changeStyle("content", "width", width + "%")
+            changeStyle(".content", "width", width + "%")
+            flushStyles();
         }
     } 
 

--- a/src/Chrome/manifest.json
+++ b/src/Chrome/manifest.json
@@ -8,7 +8,8 @@
 
   "content_scripts": [{
     "js": ["content.js"],
-    "matches": ["https://*.stackoverflow.com/questions/*"]
+    "matches": ["https://stackoverflow.com/questions/*"],
+    "run_at": "document_start"
   }],
   "permissions": ["tabs", "storage"],
   "browser_action": {
@@ -16,6 +17,4 @@
     "default_icon": "icon.png",
     "default_popup": "popup.html"
   }
-
-
 }

--- a/src/Chrome/manifest.json
+++ b/src/Chrome/manifest.json
@@ -8,6 +8,7 @@
 
   "content_scripts": [{
     "js": ["content.js"],
+    "css": ["content.css"],
     "matches": ["https://stackoverflow.com/questions/*"],
     "run_at": "document_start"
   }],


### PR DESCRIPTION
When opening a StackOverflow page with this extension, you can briefly see the normal StackOverflow layout before the extension loads.

This PR aims to remove this "flickering" effect by changing the way the stylesheets get applied.

Instead of waiting for all elements to be loaded, the extension now creates its own style element in the head and writes its styles into there. It also briefly hides the body element of the page while we generate the stylesheet to remove any remaining flickering.

This new style generation technique also improves the way the styles are applied. Instead of having a mix of "changeStyle" and `document.[...].style = [...];` the whole code can now use "changeStyle" with any CSS Selector.

---

Here is a demo of it in action. On the left side you can see how the page load currently looks, on the right side you can see how it looks after this PR.

![00086400](https://user-images.githubusercontent.com/10333196/94791130-82aa8f80-03d7-11eb-8849-6eb1af2ca733.gif)
