### PR TITLE
Add new settings for border radius and drop shadow

### DIFF
--- a/src/Chrome/content.js
+++ b/src/Chrome/content.js
@@ -104,9 +104,9 @@ function focusStack(){
     changeStyle("#content", "border-radius", borderRadius + "px");
 
     if (isShadow) {
-        changeStyle("#content", "box-shadow", shadow);
-    } else{
-        changeStyle("#content", "box-shadow", "0px 0px 0px 0px rgba(0, 0, 0, 0)")
+      changeStyle("#content", "box-shadow", shadow);
+    } else {
+      changeStyle("#content", "box-shadow", "0px 0px 0px 0px rgba(0, 0, 0, 0)");
     }
 
     // Center main content

--- a/src/Chrome/popup.css
+++ b/src/Chrome/popup.css
@@ -14,3 +14,7 @@ body{
 h3{
   line-height: 2.1rem;
 }
+
+.hidden {
+  display: none;
+}

--- a/src/Chrome/popup.html
+++ b/src/Chrome/popup.html
@@ -26,13 +26,13 @@
         
         <h3 class="coral-Detail coral-Detail--light">Options</h3>
 
-        <div class="p-t-10 shadowSwitch-wrapper">
+        <div class="p-t-10">
           <coral-switch id="switchShadow" checked>
             <span id="switchShadowLabel">Drop Shadow</span>
           </coral-switch>
         </div>
 
-        <div class="p-t-15 coral-Form--vertical shadowInput-wrapper">
+        <div class="p-t-15 coral-Form--vertical">
           <label id="custom-shadow-label" class="coral-Form-fieldlabel">
             Define a custom CSS drop shadow
           </label>

--- a/src/Chrome/popup.html
+++ b/src/Chrome/popup.html
@@ -32,12 +32,6 @@
           </coral-switch>
         </div>
 
-        <!-- <div class="p-t-15 coral-Form">
-          <coral-switch id="toggleCustomDropShadow">Define a custom drop shadow</coral-switch>
-        </div> -->
-
-        <!-- placeholder="rgba(0, 0, 0, 0.2) 0px 6px 12px 3px" -->
-
         <div class="p-t-15 coral-Form--vertical shadowInput-wrapper">
           <label id="custom-shadow-label" class="coral-Form-fieldlabel">
             Define a custom CSS drop shadow

--- a/src/Chrome/popup.html
+++ b/src/Chrome/popup.html
@@ -26,28 +26,58 @@
         
         <h3 class="coral-Detail coral-Detail--light">Options</h3>
 
-
-        <div class="p-t-10">
+        <div class="p-t-10 shadowSwitch-wrapper">
           <coral-switch id="switchShadow" checked>
-            <span id="switchShadowLabel"> Drop Shadow </span>
+            <span id="switchShadowLabel">Drop Shadow</span>
           </coral-switch>
+        </div>
+
+        <!-- <div class="p-t-15 coral-Form">
+          <coral-switch id="toggleCustomDropShadow">Define a custom drop shadow</coral-switch>
+        </div> -->
+
+        <!-- placeholder="rgba(0, 0, 0, 0.2) 0px 6px 12px 3px" -->
+
+        <div class="p-t-15 coral-Form--vertical shadowInput-wrapper">
+          <label id="custom-shadow-label" class="coral-Form-fieldlabel">
+            Define a custom CSS drop shadow
+          </label>
+          <input
+            is="coral-textfield"
+            id="shadowInput" 
+            labelledby="custom-shadow-label"
+            placeholder="valid CSS box-shadow"
+          ></input>
+        </div>
+
+        <div class="p-t-15 coral-Form coral-Form--vertical">
+          <label id="border-radius-label" class="coral-Form-fieldlabel">
+            Border radius
+          </label>
+          <coral-numberinput
+            labelledby="border-radius-label"
+            min="0"
+            max="100"
+            value="10"
+            id="borderRadiusInput"
+          ></coral-numberinput>
         </div>
 
         <div class="p-t-15 coral-Form coral-Form--vertical">
           <label id="width-label" class="coral-Form-fieldlabel">
-            Width in Percent
+            Width in percent
           </label>
           <coral-numberinput
             labelledby="width-label"
             min="1"
             max="100"
             value="65"
-            id="width-setting"
+            id="widthInput"
           ></coral-numberinput>
         </div>
 
         <form class="coral-Form coral-Form--vertical p-t-15">
-          <label id="colourInputLabel" class="coral-Form-fieldlabel">BG Colour</label>
+          <label id="colourInputLabel" class="coral-Form-fieldlabel">Background colour</label>
           <coral-colorinput 
             id="colourInput" 
             labelledby="colourInputLabel" 

--- a/src/Chrome/popup.js
+++ b/src/Chrome/popup.js
@@ -9,6 +9,15 @@ function sendMsg(msg) {
   });
 }
 
+function toggleHidden(element) {
+  var isHidden = [...element.classList].find(function(cssClass) {return cssClass === 'hidden'})
+  if (isHidden) {
+    element.classList.remove('hidden')
+  } else {
+    element.classList.add('hidden')
+  }
+}
+
 document.addEventListener('DOMContentLoaded', function () {
   var switchBtn = document.getElementById("switch")
 
@@ -22,34 +31,40 @@ document.addEventListener('DOMContentLoaded', function () {
     }
   })
 
-  var widthSetting = document.getElementById('width-setting')
-  var switchShadow = document.getElementById('switchShadow')
+  var switchShadow = document.getElementById("switchShadow");
+  var shadowInput = document.getElementById("shadowInput");
+  var borderRadiusInput = document.getElementById("borderRadiusInput");
+  var widthInput = document.getElementById("widthInput");
   var colourInput = document.getElementById('colourInput')
 
   // Wait until coral has loaded the element
-  Coral.commons.ready(widthSetting, function() {
+  Coral.commons.ready(widthInput, function() {
     
     // Load saves settings from local storage
     try {
       chrome.storage.local.get(['width'], function (data) {
-        console.log(data.width);
         // Check if local storage width is empty
         if (typeof data.width != 'string') {
-          widthSetting.value = 65;
-        } else{
-          widthSetting.value = data.width;
+          widthInput.value = 65;
+        } else {
+          widthInput.value = data.width;
         }
       })
 
-      chrome.storage.local.get(['isShadow'], function (data) {
+      chrome.storage.local.get(['isShadow', 'shadow'], function (data) {
         // Check if data.isShadow exists on local storage
         if (typeof data.isShadow == 'boolean') {
           if (data.isShadow) {
             switchShadow.setAttribute("checked")
+            if (data.shadow) {
+              shadowInput.value = data.shadow
+            } else {
+              shadowInput.value = ""
+            }
           } else{
             switchShadow.removeAttribute("checked")
           }
-        }else{
+        } else {
           switchShadow.setAttribute("checked")
         }
       })
@@ -58,8 +73,17 @@ document.addEventListener('DOMContentLoaded', function () {
         // Check if local storage width is empty
         if (typeof data.bgColour != 'string') {
           colourInput.value = "rgb(50,50,50)";
-        } else{
+        } else {
           colourInput.value = data.bgColour;
+        }
+      })
+
+      chrome.storage.local.get(['borderRadius'], function (data) {
+        // Check if local storage width is empty
+        if (typeof data.borderRadius != 'string') {
+          borderRadiusInput.value = 10;
+        } else {
+          borderRadiusInput.value = data.borderRadius;
         }
       })
 
@@ -70,10 +94,10 @@ document.addEventListener('DOMContentLoaded', function () {
     }
 
     // Set width:
-    widthSetting.on('change', function () {
+    widthInput.on('change', function () {
       // Update the value in the storage
       chrome.storage.local.set({ 
-        width: widthSetting.value
+        width: widthInput.value
       })
     })
 
@@ -83,8 +107,28 @@ document.addEventListener('DOMContentLoaded', function () {
       chrome.storage.local.set({ 
         isShadow: switchShadow.hasAttribute("checked")
       })
+
+      // Hide the custom shadow input
+      toggleHidden(shadowInput)
     })
 
+    // Set custom shadow:
+    shadowInput.on('change', function () {
+      // Update the value in the storage
+      chrome.storage.local.set({ 
+        shadow: shadowInput.value
+      })
+    })
+
+    // Set border-radius:
+    borderRadiusInput.on('change', function () {
+      // Update the value in the storage
+      chrome.storage.local.set({ 
+        borderRadius: borderRadiusInput.value
+      })
+    })
+
+    // Set background colour
     colourInput.on('change', function () {
       // Update the value in the storage
       chrome.storage.local.set({ 

--- a/src/Chrome/popup.js
+++ b/src/Chrome/popup.js
@@ -9,12 +9,24 @@ function sendMsg(msg) {
   });
 }
 
+function hideElement(element) {
+  console.log(`~ hide -> element`, element);
+  element.classList.add("hidden");
+}
+
+function showElement(element) {
+  console.log(`~ show -> element`, element);
+  element.classList.remove("hidden");
+}
+
 function toggleHidden(element) {
-  var isHidden = [...element.classList].find(function(cssClass) {return cssClass === 'hidden'})
+  var isHidden = [...element.classList].find(function (cssClass) {
+    return cssClass === "hidden";
+  });
   if (isHidden) {
-    element.classList.remove('hidden')
+    showElement(element);
   } else {
-    element.classList.add('hidden')
+    hideElement(element);
   }
 }
 
@@ -52,20 +64,24 @@ document.addEventListener('DOMContentLoaded', function () {
       })
 
       chrome.storage.local.get(['isShadow', 'shadow'], function (data) {
+        // Check if data.shadow exists on local storage
+        if (data.shadow) {
+          shadowInput.value = data.shadow;
+        } else {
+          shadowInput.value = "";
+        }
         // Check if data.isShadow exists on local storage
-        if (typeof data.isShadow == 'boolean') {
+        if (typeof data.isShadow == "boolean") {
           if (data.isShadow) {
-            switchShadow.setAttribute("checked")
-            if (data.shadow) {
-              shadowInput.value = data.shadow
-            } else {
-              shadowInput.value = ""
-            }
-          } else{
-            switchShadow.removeAttribute("checked")
+            switchShadow.setAttribute("checked");
+            showElement(shadowInput.parentElement);
+          } else {
+            switchShadow.removeAttribute("checked");
+            hideElement(shadowInput.parentElement);;
           }
         } else {
-          switchShadow.setAttribute("checked")
+          switchShadow.setAttribute("checked");
+          showElement(shadowInput.parentElement);
         }
       })
 
@@ -104,12 +120,11 @@ document.addEventListener('DOMContentLoaded', function () {
     // Set shadow:
     switchShadow.on('change', function () {
       // Update the value in the storage
-      chrome.storage.local.set({ 
-        isShadow: switchShadow.hasAttribute("checked")
-      })
-
+      chrome.storage.local.set({
+        isShadow: switchShadow.hasAttribute("checked"),
+      });
       // Hide the custom shadow input
-      toggleHidden(shadowInput)
+      toggleHidden(shadowInput.parentElement);
     })
 
     // Set custom shadow:


### PR DESCRIPTION
I use the extension a fair bit and noticed there were a few settings I wanted to change, so I thought I may as well open a PR with the changes.

This PR adds two new inputs to set the border radius and drop shadow. 

#### Drop Shadow Input 
![image](https://user-images.githubusercontent.com/13836920/111040379-bbc44280-8400-11eb-8b7d-51cd942164a7.png)
![image](https://user-images.githubusercontent.com/13836920/111040527-49079700-8401-11eb-9542-dc91b5a8aa0c.png)

- You can set a custom drop shadow by entering a valid css `box-shadow` property.
- The input is optional and only appears when when the drop shadow switch is toggled on.

#### Border Radius Input
![image](https://user-images.githubusercontent.com/13836920/111040416-dd252e80-8400-11eb-9190-7c0ddb6da1c8.png)

- You can set a custom border-radius. Thats it, nothing too special here.